### PR TITLE
Check if TouchEvent is defined first

### DIFF
--- a/src/actions/swipeable/swipeable.js
+++ b/src/actions/swipeable/swipeable.js
@@ -10,7 +10,7 @@ import {
 import { createDispatcher } from '../../utils/event'
 
 function getCoords(event) {
-  if (event instanceof TouchEvent) {
+  if ('TouchEvent' in window && event instanceof TouchEvent) {
     const touch = event.touches[0]
     return {
       x: touch ? touch.clientX : 0,


### PR DESCRIPTION
When clicking on an image in the carousel with a mouse, a ReferenceError is thrown because TouchEvent is undefined.