### PR TITLE
Accessibility : Add keyboard control using html buttons

### DIFF
--- a/src/components/Arrow/Arrow.svelte
+++ b/src/components/Arrow/Arrow.svelte
@@ -12,7 +12,7 @@
   export let disabled = false
 </script>
 
-<div
+<button
   class="sc-carousel-arrow__circle"
   class:sc-carousel-arrow__circle_disabled={disabled}
   on:click
@@ -22,7 +22,7 @@
     class:sc-carousel-arrow__arrow-next={direction === NEXT}
     class:sc-carousel-arrow__arrow-prev={direction === PREV}
   ></i>
-</div>
+</button>
 
 <style>
   :root {

--- a/src/components/Dot/Dot.svelte
+++ b/src/components/Dot/Dot.svelte
@@ -17,6 +17,12 @@
     --sc-active-dot-size: 8px;
     --sc-dot-size-animation-time: 250ms;
   }
+
+  button {
+    all: unset;
+    cursor: pointer;
+  }
+
   .sc-carousel-dot__dot {
     background-color: var(--sc-color-rgb-light);
     border-radius: 50%;

--- a/src/components/Dot/Dot.svelte
+++ b/src/components/Dot/Dot.svelte
@@ -23,6 +23,11 @@
     cursor: pointer;
   }
 
+  button:focus {
+    outline: 1px dotted #212121;
+    outline: 5px auto -webkit-focus-ring-color;
+  }
+
   .sc-carousel-dot__dot {
     background-color: var(--sc-color-rgb-light);
     border-radius: 50%;

--- a/src/components/Dot/Dot.svelte
+++ b/src/components/Dot/Dot.svelte
@@ -5,11 +5,11 @@
   export let active = false
 </script>
 
-<div
+<button
   class="sc-carousel-dot__dot"
   class:sc-carousel-dot__dot_active={active}
   on:click
-></div>
+></button>
 
 <style>
   :root {


### PR DESCRIPTION
Here is a proposal to fix #101 and add keyboard control of the carousel.

It replaces `div` by `button` to have the native keyboard control of HTML buttons. 

It resets the buttons default style to keep the original design of the dots but re adds outline on focus to let people know which dot has the focus.

Everything works fine on my side and I can reach the buttons with tab key and control the carousel with Enter or Space.

