### PR TITLE
⚡ allow `currentPageIndex` be used by the contents

### DIFF
--- a/src/components/Carousel/Carousel.svelte
+++ b/src/components/Carousel/Carousel.svelte
@@ -292,7 +292,7 @@
         "
         bind:this={particlesContainer}
       >
-        <slot {loaded}></slot>
+        <slot {loaded} {currentPageIndex}></slot>
       </div>
       {#if autoplayProgressVisible}
         <div class="sc-carousel-progress__container">


### PR DESCRIPTION
Letting the default slots read `currentPageIndex` would be useful and allow more flexibility.

I had been trying to copy Steam's carousel, though I was able to do it, I had to declare few more variables since `currentPageIndex` can't be read by the default slots.
![image](https://user-images.githubusercontent.com/62589492/167125471-a84bd5b6-3b49-4660-b017-93666d6fb2ca.png)
![Carousel](https://user-images.githubusercontent.com/62589492/167125251-00fee13b-8081-4cbe-abcf-330c90bef97a.gif)

Having the default slots read `currentPageIndex` will remove redundancy.
![image](https://user-images.githubusercontent.com/62589492/167123360-2ec28f35-ba8e-4549-81b9-b50ddcd0a880.png)