### PR TITLE
Remove preventDefault from swipeable and tappable.

### DIFF
--- a/src/actions/swipeable/swipeable.js
+++ b/src/actions/swipeable/swipeable.js
@@ -70,7 +70,6 @@ export function swipeable(node, { thresholdProvider }) {
   }
 
   function handleUp(event) {
-    event.preventDefault();
     removeEndEventListener(window, handleUp)
     removeMoveEventListener(window, handleMove)
 

--- a/src/actions/tappable/tappable.js
+++ b/src/actions/tappable/tappable.js
@@ -42,7 +42,6 @@ export function tappable(node) {
   }
 
   function handleTapend(event) {
-    event.preventDefault();
     removeFocusoutEventListener(node, handleTapend)
 
     const touch = event.changedTouches[0]


### PR DESCRIPTION
This was preventing carousel particles that contained clickable items from
working properly on mobile devices.

Removing preventDefault() from both locations allows these items to
response properly when clicked. No adverse behavior had been observed.
Tested on a Pixel 2 phone monitored with chrome dev tools.