### PR TITLE
Make svelte-carousel work in svelte-kit build version too

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Svelte carousel",
   "main": "src/main.js",
   "module": "src/main.js",
+  "svelte": "src/main.js",
   "author": "vadimkorr",
   "type": "module",
   "repository": {


### PR DESCRIPTION
by adding a svelte property (not sure if this is really the way to go!) we can make the runtime build version in svelte kit make work too. Without this, things end badly when running the build version:

```
0|itis-tng | TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".svelte" for /home/oetiker/checkouts/itis-tng-svelte-tailwind/node_modules/svelte-carousel/src/components/Carousel/Carousel.svelte
0|itis-tng |     at new NodeError (node:internal/errors:387:5)
0|itis-tng |     at Object.getFileProtocolModuleFormat [as file:] (node:internal/modules/esm/get_format:76:11)
0|itis-tng |     at defaultGetFormat (node:internal/modules/esm/get_format:118:38)
0|itis-tng |     at defaultLoad (node:internal/modules/esm/load:81:20)
0|itis-tng |     at nextLoad (node:internal/modules/esm/loader:165:28)
0|itis-tng |     at ESMLoader.load (node:internal/modules/esm/loader:608:26)
0|itis-tng |     at ESMLoader.moduleProvider (node:internal/modules/esm/loader:464:22)
0|itis-tng |     at new ModuleJob (node:internal/modules/esm/module_job:63:26)
0|itis-tng |     at ESMLoader.#createModuleJob (node:internal/modules/esm/loader:483:17)
0|itis-tng |     at ESMLoader.getModuleJob (node:internal/modules/esm/loader:441:34)
```