### PR TITLE
Expose pagesCount and currentPageIndex in next and prev slots

### DIFF
--- a/src/components/Carousel/Carousel.svelte
+++ b/src/components/Carousel/Carousel.svelte
@@ -257,7 +257,11 @@
 <div class="sc-carousel__carousel-container">
   <div class="sc-carousel__content-container">
     {#if arrows}
-      <slot name="prev" showPrevPage={methods.showPrevPage}>
+      <slot name="prev"
+        showPrevPage={methods.showPrevPage}
+        pagesCount={pagesCount}
+        currentPageIndex={currentPageIndex}
+      >
         <div class="sc-carousel__arrow-container">
           <Arrow
             direction="prev"
@@ -301,7 +305,11 @@
       {/if}
     </div>
     {#if arrows}
-      <slot name="next" showNextPage={methods.showNextPage}>
+      <slot name="next"
+        showNextPage={methods.showNextPage}
+        pagesCount={pagesCount}
+        currentPageIndex={currentPageIndex}
+      >
         <div class="sc-carousel__arrow-container">
           <Arrow
             direction="next"


### PR DESCRIPTION
I have a situation where I want to have custom next and previous slot, but can't change the next button styling when the carousel is at the limit of pages.
I can access the currentPageIndex in the `dots` slot and that is great. This PR should make it accessible in scope for the next and previous slots as well.