### PR TITLE
added type to carousel buttons

### DIFF
--- a/src/components/Arrow/Arrow.svelte
+++ b/src/components/Arrow/Arrow.svelte
@@ -16,6 +16,7 @@
   class="sc-carousel-button sc-carousel-arrow__circle"
   class:sc-carousel-arrow__circle_disabled={disabled}
   on:click
+  type="button"
 >
   <i
     class="sc-carousel-arrow__arrow"


### PR DESCRIPTION
Added type="button" to carousel arrow buttons this allows the component to be used in forms. 