### PR TITLE
Fix error: No exports for svelte in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,11 @@
   "main": "src/main.js",
   "module": "src/main.js",
   "svelte": "src/main.js",
+  "exports": {
+    ".": {
+        "svelte": "./src/main.js"
+    }
+  },
   "author": "vadimkorr",
   "type": "module",
   "repository": {


### PR DESCRIPTION
<img width="1206" alt="Screenshot 2024-08-10 at 2 26 54 PM" src="https://github.com/user-attachments/assets/3a591172-b28a-4421-8cfa-4ac682e6a09d">
Fix no exports condition warning
Using the svelte field in package.json to point at .svelte source files is deprecated and you must use a svelte [export condition](https://nodejs.org/api/packages.html#conditional-exports). vite-plugin-svelte 3 still resolves it as a fallback, but in a future major release this is going to be removed and without exports condition resolving the library is going to fail.